### PR TITLE
FIXES #2 and #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cachable was originally designed to cache navigation hierarchies as objects to i
 site performance, but has since been re-written to allow any object to be cached.
 
 At its core is `Zend_Cache` and as such the module can use either the memcache or
-memcached Zend backends `code/_config.php`.
+memcached Zend backends, see: `code/_config.php`.
 
 ## Installation
 
@@ -30,10 +30,10 @@ Add a new line under the "require" block:
 Add a new block under the "repositories" block:
 
 
-      {
-       "type": "vcs",
-       "url": "https://github.com/deviateltd/silverstripe-cacheable.git"
-      }
+    {
+        "type": "vcs",
+        "url": "https://github.com/deviateltd/silverstripe-cacheable.git"
+    }
 
 Now run `dev/build` via the browser or command line - and don't forget to flush.
 
@@ -51,6 +51,73 @@ via the browser, you'll likely exceed one or both of PHP's `max_execution_time` 
 notably Debian-like O/S', the CLI SAPI is automatically allocated an unlimited 
 execution time and memory limit without the need to manually call `ini_set()` anywhere.
 
-If you want to boost these as a one off just to run these tasks, look at PHP's `-d` 
+If you want to boost these PHP settings as a one off for these tasks, look at PHP's `-d` 
 switch that allows you to arbitrarily override settings normally set in scripts
-using `ini_set`.
+using `ini_set()`.
+
+### How to cache an object
+
+The object(s) that the module will cache are decided simply by the addition of a special
+`<% with %>` block. For example; by wrapping the following block around your call(s) to `$Menu()` and assuming
+you've primed your cache using the BuildTask above, this will vastly improve the performance
+of your site:
+
+    <% with $CachedData %>
+    ...Menu template logic here...
+    <% end_with %>
+
+
+### Options
+
+By default the module will use `memcached` as its chosen cache-store if the extension
+is loaded. However this can be overridden in your project's YML config, possible values
+are `memcache`, `memcached` or `fs`:
+
+    CacheableConfig:
+      # Use Filesystem instead of default memcached
+      cache_mode: fs
+
+The module uses its own default "server" parameters to pass to both `memcached` and `memcache`
+but there is some scope to override these in your project's YML config:
+
+    CacheableConfig:
+      # Override module defaults for the 'server' array
+      server_opts:
+        memcached:
+          host: localhost
+          port: 11212
+          weight: 2
+
+By default the module will attempt to rebuild the cache if one doesn't exist, whenever
+a user hits the site. For sites with a large number of page objects, this probably isn't
+a good idea, so this can be overridden in config also:
+
+    CacheableConfig:
+    # Instruct Cacheable not to try and build a cache via the "first user pays" approach
+      build_cache_onload: false
+
+__Note:__ The cache rebuild is also skipped when a flush is in effect.
+
+The Rebuild task can be passed a `Versioned` stage "Stage" or "Live" which will restrict
+rebuilding the cache to just the passed mode, thus:
+
+    #> sudo -u www-data ./framework/sake dev/tasks/CacheableNavigation_Rebuild Mode=Live
+
+## FAQ
+
+ Q: Why the references to "CacheableNavigation" all over the place?
+
+ A: The module was originally designed to cache mega/side/footer menu's which are 
+ usually the biggest performance killers on any moderately sized SilverStripe site.
+ These references will be gradually refactored out.
+
+ Q: How does this module compare with SilverStripe's [Partial Caching](http://doc.silverstripe.org/en/developer_guides/performance/partial_caching) feature?
+
+ A: A full performance comparison methodology has been prepared, and we await the results. However,
+ `Cacheable` improves over Partial Caching in that, there's never one user who needs to
+ bare the overhead of priming the cache. With `Cacheable` this is done via a BuildTask with the added
+ bonus of avoiding that rare beast the [Cache Stampede](http://en.wikipedia.org/wiki/Cache_stampede).
+
+ Q: How does this module compare with a site without it, but with an Opcode Cache running?
+
+ A: A full performance comparison methodology has been prepared, and we await the results.

--- a/_config.php
+++ b/_config.php
@@ -1,49 +1,18 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: normann.lou
- * Date: 15/03/2015
- * Time: 6:24 PM
+ * 
+ * @author Deviate Ltd 2015 http://www.deviate.net.nz
+ * @package silverstripe-cachable
+ * 
+ * Configure the module's storage:
+ * 
+ * The default is to use memcached for the cache store, but this can be overriden in 
+ * project YML config. You can also optionally override the default "server" array 
+ * normally passed to {@link SS_Cache} and Zend_Cache. See the README.
  */
 
-if(extension_loaded('memcached')){
-    // Libmemcached is enabled.
-    SS_Cache::add_backend(
-        'cacheablestore',
-        'Libmemcached',
-        array(
-            'servers' => array(
-                'host' => 'localhost',
-                'port' => 11211,
-                'weight' => 1,
-            ),
-        )
-    );
-}else if(class_exists('Memcache')){
-    // Memcached is enabled.
-    SS_Cache::add_backend(
-        'cacheablestore',
-        'Memcached',
-        array(
-            'servers' => array(
-                'host' => 'localhost',
-                'port' => 11211,
-                'persistent' => true,
-                'weight' => 1,
-                'timeout' => 5,
-                'retry_interval' => 15,
-                'status' => true,
-                'failure_callback' => ''
-            )
-        )
-    );
-}else{
-    $cacheable_store_dir = TEMP_FOLDER . DIRECTORY_SEPARATOR . 'cacheable-navigation';
-    if (!is_dir($cacheable_store_dir)) mkdir($cacheable_store_dir);
+define('CACHEABLE_STORE_DIR', TEMP_FOLDER . DIRECTORY_SEPARATOR . 'cacheable-navigation');
+define('CACHEABLE_STORE_NAME', 'cacheablestore');
 
-    SS_Cache::add_backend('cacheablestore', 'File', array(
-        'cache_dir' => $cacheable_store_dir,
-    ));
-}
-
-SS_Cache::pick_backend('cacheablestore', 'Cached_Navigation', 15);
+CacheableConfig::configure();
+SS_Cache::pick_backend(CACHEABLE_STORE_NAME, 'Cached_Navigation', 15);

--- a/code/tasks/CacheableNavigation_Clean.php
+++ b/code/tasks/CacheableNavigation_Clean.php
@@ -28,9 +28,9 @@ class CacheableNavigation_Clean extends BuildTask {
      * @param SS_HTTPRequest $request
      */
     public function run($request) {
-        SS_Cache::pick_backend('cacheablestore', 'Cached_Navigation', 15);
-        SS_Cache::factory('cacheablestore')->clean('all');
+        SS_Cache::pick_backend(CACHEABLE_STORE_NAME, 'Cached_Navigation', 15);
+        SS_Cache::factory(CACHEABLE_STORE_NAME)->clean('all');
         $line_break = Director::is_cli()?"\n":"<br />";
-        echo $line_break."cacheablestore cleaned".$line_break;
+        echo $line_break . CACHEABLE_STORE_NAME . " cleaned".$line_break;
     }
 }

--- a/code/tasks/CacheableNavigation_Rebuild.php
+++ b/code/tasks/CacheableNavigation_Rebuild.php
@@ -36,9 +36,14 @@ class CacheableNavigation_Rebuild extends BuildTask {
      * @return void
      */
     public function run($request) {
-        $line_break = Director::is_cli() ? PHP_EOL : "<br />";
-
+        ini_set('memory_limit', -1);
+        if((int)$maxTime = $request->getVar('MaxTime')) {
+            ini_set('max_execution_time', $maxTime);
+        }
+        
         $currentStage = Versioned::current_stage();
+        
+        echo 'Cachestore: ' . CacheableConfig::current_cache_mode() . $this->lineBreak(2);
         
         // Restrict cache rebuild to the given mode
         if($mode = $request->getVar('Mode')) {
@@ -77,13 +82,13 @@ class CacheableNavigation_Rebuild extends BuildTask {
                         $count++;
                         $service->set_model($page);
                         $percent = $this->percentageComplete($count, $pages->count());
-                        echo 'Caching: ' . $page->Title . ' (' . $percent . ')' . $line_break;
+                        echo 'Caching: ' . $page->Title . ' (' . $percent . ')' . $this->lineBreak();
                         $service->refreshCachedPage();
                     }
                 }
                 
                 $service->completeBuild();
-                echo $pages->count()." pages cached in $stage mode for subsite " . $config->ID . $line_break;
+                echo $pages->count()." pages cached in $stage mode for subsite " . $config->ID . $this->lineBreak();
             }
             
             if(class_exists('Subsite')){
@@ -105,5 +110,17 @@ class CacheableNavigation_Rebuild extends BuildTask {
     public function percentageComplete($count, $total) {
         $calc = (((int)$count / (int)$total) * 100);
         return round($calc, 1) . '%';
+    }
+    
+    /**
+     * 
+     * Generate an O/S independent line-break, for as many times as required.
+     * 
+     * @param number $mul
+     * @return string
+     */
+    public function lineBreak($mul = 1) {
+        $line_break = Director::is_cli() ? PHP_EOL : "<br />";
+        return str_repeat($line_break, $mul);
     }
 }


### PR DESCRIPTION
- Refactored _config.php, put logic into new CacheableConfig class.
- Added ability for project-specific YML config to override defaults
- Added is_flush() static. Useful for skipping cache-creation when flush=1
- Added method to retrive current store method (File etc)
- Replaced 'loose' config strings with constants
- Added utility line-break method to Rebuild task.
- Updated README, changed inline docs
