### PR TITLE
FIX: Fixes #24

### DIFF
--- a/code/convert/CacheableDataModelConvert.php
+++ b/code/convert/CacheableDataModelConvert.php
@@ -30,9 +30,13 @@ class CacheableDataModelConvert extends Convert {
 
         $cacheable_functions = $cacheable->get_cacheable_functions();
         foreach($cacheable_functions as $function) {
-            // We _run_ each function and assign its output via __set() so 
-            // that cached-objects "just work" (tm).
-            $cacheable->__set($function, $model->$function());
+            /*
+             * Running tests inside a project with its own YML config for 
+             * cacheable_fields and cacheable_functions will fail if we don't check first
+             */
+            if(method_exists($model, $function)) {
+                $cacheable->__set($function, $model->$function());
+            }
         }
 
         return $cacheable;

--- a/code/jobs/CachableChunkedRefreshJob.php
+++ b/code/jobs/CachableChunkedRefreshJob.php
@@ -209,7 +209,7 @@ class CachableChunkedRefreshJob extends AbstractQueuedJob implements QueuedJob {
             
             // Only if refreshCachedPage() signals it completed A-OK and saved its payload
             // to the cachestore, do we then update the job status to 'complete'.
-            if(!$service->refreshCachedPage()) {
+            if(!$service->refreshCachedPage(true)) {
                 $errorMsg = 'Unable to cache object#' . $object->ID;
                 $this->addMessage($errorMsg);
             }

--- a/code/services/CacheableNavigationService.php
+++ b/code/services/CacheableNavigationService.php
@@ -191,10 +191,11 @@ class CacheableNavigationService {
      * 
      * "Removes"  a cache-entry for the object (page) given in $this->get_model().
      * 
+     * @param boolean $forceRemoval Whether to unset() children in {@link CacheableSiteTree::removeChild()}.
      * @return boolean  false if the underlying calls to {@link Zend_Cache_Core::load()}
      *                  or {@link Zend_Cache_Core::save()} fail for any reason.
      */
-    public function removeCachedPage() {
+    public function removeCachedPage($forceRemoval = true) {
         $frontend = $this->getCacheableFrontEnd();
         $id = $this->getIdentifier();
         if(!$this->_cached) {
@@ -216,13 +217,13 @@ class CacheableNavigationService {
         if(isset($site_map[$model->ID])) {
             $parentCached = $site_map[$model->ID]->getParent();
             if($parentCached && $parentCached->ID && isset($site_map[$parentCached->ID])) {
-                $site_map[$parentCached->ID]->removeChild($model->ID);
+                $site_map[$parentCached->ID]->removeChild($model->ID, $forceRemoval);
             }
         }
         
         if($model->ParentID) {
             if(isset($site_map[$model->ParentID])) {
-                $site_map[$model->ParentID]->removeChild($model->ID);
+                $site_map[$model->ParentID]->removeChild($model->ID, $forceRemoval);
             }
         }
         
@@ -248,10 +249,11 @@ class CacheableNavigationService {
      * Note: If a cache entry already exists for a given object ID, it is removed 
      * and replaced.
      * 
-     * @return boolean  false if the underlying calls to {@link Zend_Cache_Core::load()}
-     *                  or {@link Zend_Cache_Core::save()} fail for any reason.
+     * @param boolean $forceRemoval Whether to unset() children in {@link CacheableSiteTree::removeChild()}.
+     * @return boolean              False if the underlying calls to {@link Zend_Cache_Core::load()}
+     *                              or {@link Zend_Cache_Core::save()} fail for any reason.
      */
-    public function refreshCachedPage() {
+    public function refreshCachedPage($forceRemoval = false) {
         $model = $this->get_model();
         $cacheableClass = 'CacheableSiteTree';
         $classes = array_reverse(ClassInfo::ancestry(get_class($model)));
@@ -277,7 +279,7 @@ class CacheableNavigationService {
         if(isset($site_map[$cacheable->ID])) {
             $parentCached = $site_map[$cacheable->ID]->getParent();
             if($parentCached && $parentCached->ID && isset($site_map[$parentCached->ID])) {
-                $site_map[$parentCached->ID]->removeChild($cacheable->ID);
+                $site_map[$parentCached->ID]->removeChild($cacheable->ID, $forceRemoval);
             }
             
             $children = $site_map[$cacheable->ID]->getAllChildren();

--- a/code/tasks/CacheableNavigation_Rebuild.php
+++ b/code/tasks/CacheableNavigation_Rebuild.php
@@ -134,7 +134,7 @@ class CacheableNavigation_Rebuild extends BuildTask {
                             $percentComplete = $this->percentageComplete($i, $pageCount);
                             echo 'Caching: ' . trim($page->Title) . ' (' . $percentComplete . ') ' . self::new_line();
                             $service->set_model($page);
-                            $service->refreshCachedPage();
+                            $service->refreshCachedPage(true);
                         }
                     }
                 }

--- a/code/view/CacheableSiteTree.php
+++ b/code/view/CacheableSiteTree.php
@@ -123,15 +123,34 @@ class CacheableSiteTree extends CacheableData {
 
     }
 
-    public function addChild(CacheableData $data){
+    /**
+     * 
+     * @param CacheableData $data
+     * @return void
+     */
+    public function addChild(CacheableData $data) {
         $this->Children[$data->ID] = $data;
     }
 
-    public function removeChild($childID){
-        if(isset($this->Children[$childID])){
-            unset($this->Children[$childID]);
+    /**
+     * 
+     * "Removes" an item from the Children array, but by default not using PHP's 
+     * unset() function becuase this will cause PHP to reset its internal array 
+     * pointer and we need to maintain array state. Use the $force param to unset.
+     * 
+     * @param int $childID
+     * @param boolean $force    Invoke PHP's unset() function on the selected item.
+     * @return void
+     */
+    public function removeChild($childID, $force = true) {
+        if(isset($this->Children[$childID])) {
+            if($force === true) {
+                unset($this->Children[$childID]);
+            } else {
+                $this->Children[$childID] = CacheableSiteTree::create(); // dummy
+            }
         }
-     }
+    }
 
     public function setParent(CacheableData $data){
         $this->Parent = $data;
@@ -141,7 +160,11 @@ class CacheableSiteTree extends CacheableData {
         return $this->Parent;
     }
 
-    public function getAllChildren(){
+    /**
+     * 
+     * @return array
+     */
+    public function getAllChildren() {
         return $this->Children;
     }
 
@@ -211,36 +234,6 @@ class CacheableSiteTree extends CacheableData {
        if(empty($this->ParentID)) return false;
         $parent = $this->getParent();
         return !$parent || !$parent->exists() || $parent->isOrphaned();
-    }
-
-    function debug() {
-        $message = "<h3>cacheable data: ".get_class($this)."</h3>\n<ul>\n";
-        $message .= "\t<li>Cached Fields:\n<ul>\n";
-        foreach($this->get_cacheable_fields() as $field){
-            $message .= "\t<li>$field: ". $this->$field . "</li>\n";
-        }
-        $message .= "</ul>\n". "</li>\n";
-
-        $message .= "\t<li>Cached Functions:\n<ul>\n";
-        foreach($this->get_cacheable_functions() as $function){
-            $message .= "\t<li>$function: ". $this->$function . "</li>\n";
-        }
-        $message .= "</ul>\n". "</li>\n";
-
-        if($this->Parent) {
-            $message .= "\t<li>Cached Parent: ".$this->Parent->ID. ": ".$this->Parent->Title."</li>\n";
-        }
-
-        if(count($this->Children)){
-            $message .= "\t<li>Cached Children:\n<ul>\n";
-            foreach($this->Children as $childID => $child){
-                $message .= "\t<li>Cached child: ".$childID. ": ".$child->Title."</li>\n";
-            }
-            $message .=  "</ul>\n</li>\n";
-        }
-        $message .= "</ul>\n";
-
-        return $message;
     }
 
     function debug_simple(){

--- a/tests/CacheableNavigationServiceTest.php
+++ b/tests/CacheableNavigationServiceTest.php
@@ -15,10 +15,10 @@ class CacheableNavigationServiceTest extends SapphireTest {
     protected static $fixture_file = 'fixtures/CacheableNavigationServiceTest.yml';
     
     /**
-     * Cleanup after ourselves
+     * Cleanup
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function setUp() {
+        parent::setUp();
         
         // Cleanup our test-only caches
         SS_Cache::factory(CACHEABLE_STORE_FOR)->clean(
@@ -32,7 +32,7 @@ class CacheableNavigationServiceTest extends SapphireTest {
      */
     public function testRefreshCachedPage() {
         $config = $this->objFromFixture('SiteConfig', 'default');
-        $model = $this->objFromFixture('SiteTree', 'test-page-1');
+        $model = $this->objFromFixture('SiteTree', 'servicetest-page-1');
         $service = new CacheableNavigationService('Live', $config, $model);
         
         // Cache should be empty
@@ -45,7 +45,7 @@ class CacheableNavigationServiceTest extends SapphireTest {
         
         $cachedObject = $service->_cached->get_site_map();
         $this->assertCount(1, $cachedObject);
-        // Why is $cachedObject not zero-indexed?
+        // $cachedObject not zero-indexed as array keys are taken for SS-generated ID's from each fixture
         $this->assertInstanceOf('CacheableSiteTree', $cachedObject[1]);
         $this->assertEquals('This is a simple page to be cached', $cachedObject[1]->Title);
     }
@@ -54,7 +54,7 @@ class CacheableNavigationServiceTest extends SapphireTest {
      * 
      */
     public function testRemoveCachedPage() {
-        $model = $this->objFromFixture('SiteTree', 'test-page-1');
+        $model = $this->objFromFixture('SiteTree', 'servicetest-page-1');
         $service = new CacheableNavigationService('Live', null, $model);
         
         // Entire cache should be empty
@@ -66,7 +66,7 @@ class CacheableNavigationServiceTest extends SapphireTest {
         $this->assertInstanceOf('CachedNavigation', $service->_cached);
        
         $cachedObject = $service->_cached->get_site_map();
-        // Why is $cachedObject not zero-indexed?
+        // $cachedObject not zero-indexed as array keys are taken for SS-generated ID's from each fixture
         $this->assertCount(1, $cachedObject);
         $this->assertInstanceOf('CacheableSiteTree', $cachedObject[1]);
         
@@ -101,7 +101,7 @@ class CacheableNavigationServiceTest extends SapphireTest {
      * 
      */
     public function testCompleteBuild() {
-        $model = $this->objFromFixture('SiteTree', 'test-page-1');
+        $model = $this->objFromFixture('SiteTree', 'servicetest-page-1');
         $service = new CacheableNavigationService('Live', null, $model);
         
         // Cache should be empty

--- a/tests/CacheableSiteTreeTest.php
+++ b/tests/CacheableSiteTreeTest.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ *  
+ * @author Deviate Ltd 2014-2015 http://www.deviate.net.nz
+ * @package silverstripe-cachable
+ */
+class CacheableSiteTreeTest extends SapphireTest {
+    
+    /**
+     * 
+     * @var string
+     */
+    protected static $fixture_file = 'fixtures/CacheableSiteTreeTest.yml';
+    
+    /**
+     * Cleanup after ourselves
+     */
+    public function setUp() {
+        parent::setUp();
+        
+        // Cleanup our test-only caches
+        SS_Cache::factory(CACHEABLE_STORE_FOR)->clean(
+            Zend_Cache::CLEANING_MODE_MATCHING_TAG, 
+            array(CACHEABLE_STORE_TAG_DEFAULT_TEST)
+        );
+    }
+    
+    /**
+     * 
+     * Issue #24 described a scenario where updated SiteTree objects
+     * would become appended to the cached list and not updated in-place as expected.
+     * 
+     * Note: This is _not_ a proper _unit_ test, it's more akin to a functional test:
+     *  - It doesn't directly exercise {@link CacheableSiteTree::removeChild()}.
+     *  - removeChild() is called while populating/updating the object-cache by {@link CacheableNavigationService::refreshCachedPage()}
+     */
+    public function testRemoveChild() {
+        $config = $this->objFromFixture('SiteConfig', 'default');
+        $parent = $this->objFromFixture('SiteTree', 'sitetreetest-page-1');
+        $children = $parent->Children()->toArray();
+        $models = array_merge(array($parent), $children);
+        
+        // Fake a rebuild task - Populate the object-cache with our fixture data
+        $i = 0;
+        foreach($models as $model) {
+            $i++;
+            $varKey = "page" . $i;
+            $$varKey = $model;
+            $service = new CacheableNavigationService('Live', $config, $model);
+            $service->refreshCachedPage();
+        }
+        
+        // Fetch the cache
+        $objCache = $service->getObjectCache();
+        $siteMap = $objCache->get_site_map();
+        $childrenArr = $siteMap[1]->getAllChildren();
+        
+        // Array position check #1
+        $firstItem = reset($childrenArr);
+        $this->assertCount(2, $childrenArr);
+        $this->assertEquals('This is a child page 1', $firstItem->Title);
+        
+        // Update only the first child with some new data so we can later check it stays in the same position
+        $page2->ShowInMenu = 0;
+        $page2->write();
+        $page2->publish('Stage', 'Live');
+        
+        // Update the object-cache with "CMS updated" data
+        $service = new CacheableNavigationService('Live', $config, $page2);
+        $service->refreshCachedPage(false); // Don't unset child items. Re-use array key.
+        
+        // Re-fetch the cache
+        $objCache = $service->getObjectCache();
+        $siteMap = $objCache->get_site_map();
+        $childrenArr = $siteMap[1]->getAllChildren();
+
+        // Array position check #2 - ensure that the recently updated item hasn't been
+        // appended, but is still in the correct (same) position within the Children array
+        $firstItem = reset($childrenArr);
+        $this->assertCount(2, $childrenArr);
+        $this->assertEquals('This is a child page 1', $firstItem->Title);
+    }
+    
+}
+

--- a/tests/fixtures/CacheableNavigationServiceTest.yml
+++ b/tests/fixtures/CacheableNavigationServiceTest.yml
@@ -1,5 +1,5 @@
 SiteTree:
-  test-page-1:
+  servicetest-page-1:
     Title: 'This is a simple page to be cached'
     Content: 'Cache me!'
 SiteConfig:

--- a/tests/fixtures/CacheableSiteTreeTest.yml
+++ b/tests/fixtures/CacheableSiteTreeTest.yml
@@ -1,0 +1,15 @@
+SiteTree:
+  sitetreetest-page-1:
+    ID: 1
+    Title: 'This is a parent page'
+  sitetreetest-page-2:
+    ID: 2
+    Title: 'This is a child page 1'
+    Parent: =>SiteTree.sitetreetest-page-1
+  sitetreetest-page-3:
+    ID: 3
+    Title: 'This is a child page 2'
+    Parent: =>SiteTree.sitetreetest-page-1
+SiteConfig:
+  default:
+    Title: Default


### PR DESCRIPTION
- Updated cache-objects would be appended to lists, list order is now preserved.
- Modified CacheableData::Debug() method for improved debugging.
- Removed redundant debug() method on CacheableSiteTree.
- Added check for non-existent cacheable_functions.
- Added unit test to cover off changes in #24.
