### PR TITLE
FIX: Undocumented: Errors thrown if CacheableNavigation() returns null.

### DIFF
--- a/code/tasks/CacheableNavigation_Rebuild.php
+++ b/code/tasks/CacheableNavigation_Rebuild.php
@@ -244,6 +244,7 @@ class CacheableNavigation_Rebuild extends BuildTask {
     }
     
     /**
+     * 
      * Summarise the task's configuration details at the end of a run.
      * 
      * @param string $totalTime
@@ -266,12 +267,13 @@ class CacheableNavigation_Rebuild extends BuildTask {
          * Is the system underpowered enough such that {@link CacheableConfig::configure_memory_limit()}
          * has kicked-in? Notify the user accordingly.
          */
-        $memMode = CacheableConfig::$ini_modified_memory_limit ? 'Modified' : 'PHP Default';
+        $memMode = CacheableConfig::$ini_modified_memory_limit ? 'Auto-modified' : 'PHP Default';
         
         echo 'Job Queue: ' . $queueOn . $queueSkipped . self::new_line();
         echo 'Cache backend: ' . CacheableConfig::current_cache_mode() . self::new_line();
         echo 'Peak memory: ' . $this->memory() . 'Mb' . self::new_line();
         echo 'Execution time: ' . $totalTime . 's' . self::new_line();
         echo 'System memory_limit: ' . ini_get('memory_limit') . ' (' . $memMode . ')' . self::new_line();
+        echo 'Cache directory: ' . CACHEABLE_STORE_DIR . self::new_line();
     }
 }

--- a/code/view/CacheableSiteTree.php
+++ b/code/view/CacheableSiteTree.php
@@ -226,16 +226,27 @@ class CacheableSiteTree extends CacheableData {
         }
     }
     private $_cached_is_section = null;
+    
+    /**
+     * 
+     * @return boolean
+     */
     public function isSection() {
-        if($this->_cached_is_section === null){
-            if($this->isCurrent()) $this->_cached_is_section = true;
-            else{
-                $currentPage = Director::get_current_page();
-                $navigation = $this->CachedNavigation();
-                $ancestors = $navigation->getAncestores($currentPage->ID);
-                $this->_cached_is_section = $currentPage instanceof SiteTree && in_array($this->ID, $ancestors->column());
+        $isSection = false;
+        if($this->_cached_is_section === null) {
+            if($this->isCurrent()) {
+                $isSection = true;
+            } else {
+                if($navigation = $this->CachedNavigation()) {
+                    $currentPage = Director::get_current_page();
+                    $ancestors = $navigation->getAncestores($currentPage->ID);
+                    $isSection = $currentPage instanceof SiteTree && in_array($this->ID, $ancestors->column());
+                }
             }
+            
+            $this->_cached_is_section = $isSection;
         }
+        
         return $this->_cached_is_section;
     }
 


### PR DESCRIPTION
FIX: Also added patch that Fixes #35.
