### PR TITLE
FIX: Fixes #48 No entry cache-entry found caused site-performance loss.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ of your caches. The URI is: `/cacheable/inspector` and it provides the following
  * The backend currently in-use
  * Cache file-listing, no. files, total cache disk usage, cache last-updated time etc ("File" backend only)
 
+## Known issues
+
+Sites that utilise controller-only "Pages" aren't necessarily related to a `SiteTree` object
+and therefore will have no entry to reference in the object-cache. In these instances e.g. `/admin/login`
+we default to using the homepage's cache-entry.
+
 ## FAQ
 
  Q: Why the references to "CacheableNavigation" all over the place?

--- a/code/extensions/Cacheable.php
+++ b/code/extensions/Cacheable.php
@@ -181,18 +181,25 @@ class Cacheable extends SiteTreeExtension {
 
     /**
      * 
+     * Usually used in template logic inside <% with %> blocks.
+     * 
+     * @see README.md
      * @return mixed ContentController | array
+     * @todo What to do with controller URLs other than returning the homepage's cache?
      */
     public function CachedData() {
-        if($this->owner->exists()) {
-            if($cachedNavigiation = Config::inst()->get('Cacheable', '_cached_navigation')) {
-                if($cachedNavigiation->isUnlocked() && $cachedNavigiation->get_completed()) {
-                    $site_map = $cachedNavigiation->get_site_map();
-                    if(!empty($site_map[$this->owner->ID])) {
-                        return $site_map[$this->owner->ID];
-                    }
-                    return array();
+        if($cachedNavigiation = Config::inst()->get('Cacheable', '_cached_navigation')) {
+            if($cachedNavigiation->isUnlocked() && $cachedNavigiation->get_completed()) {
+                $site_map = $cachedNavigiation->get_site_map();
+                if(!empty($site_map[$this->owner->ID])) {
+                    return $site_map[$this->owner->ID];
                 }
+                
+                /*
+                 * Prevent errors and go-slows for controller URLs e.g. /admin 
+                 * and return the homepage's cache as a 'sensible' default
+                 */
+                return $site_map[1];
             }
         }
 


### PR DESCRIPTION
- Updated docs accordingly.
